### PR TITLE
객체 null check 조건문 개선

### DIFF
--- a/src/main/java/com/hwangwongyu/news/article/ArticleController.java
+++ b/src/main/java/com/hwangwongyu/news/article/ArticleController.java
@@ -1,6 +1,7 @@
 package com.hwangwongyu.news.article;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.ObjectUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,7 +32,7 @@ public class ArticleController {
     @GetMapping("/articles/{id}")
     public ArticleDTO findArticleById(@PathVariable long id) {
         ArticleDTO article = articleService.findArticleById(id);
-        if(article != null)
+        if(ObjectUtils.isEmpty(article) == false)
             return article;
         else
             return null;

--- a/src/main/java/com/hwangwongyu/news/user/UserController.java
+++ b/src/main/java/com/hwangwongyu/news/user/UserController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -50,7 +51,7 @@ public class UserController {
     public ResponseEntity<UserDTO> findUserById(@PathVariable long id)
     {
         UserDTO user = userService.findUserById(id);
-        if(user != null)
+        if(ObjectUtils.isEmpty(user) == false)
             return new ResponseEntity(user, HttpStatus.OK);
         else
             return new ResponseEntity("유저 정보가 없습니다", HttpStatus.NOT_FOUND);


### PR DESCRIPTION
### 개선 목적
`== null`, 컬렉션의 `isEmpty()` 메서드를 이미 포함하고 있는 `ObjectUtils` 유틸 메서드인 `isEmpty()`로 통일하여
NPE 방지 코드의 가독성, 안전성, 유지보수성 향상

### `ObjectUtils` 유틸 클래스 메서드인 `isEmpty()` 코드
<img src="https://user-images.githubusercontent.com/15853498/113551833-467b1480-9630-11eb-9ed7-7ef8c1f7f4f8.png" width="60%" height="70%"> 
